### PR TITLE
Prevent initial useEffect call in Feed component

### DIFF
--- a/src/components/front-page-feed/index.tsx
+++ b/src/components/front-page-feed/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 
 import PostFeed from '@/components/post-feed';
 import sublinksClient from '@/utils/client';
@@ -23,8 +23,10 @@ const Feed = ({ posts, site }: FeedProps) => {
   // @todo: Set this to the users default feed type
   const [postFeedType, setPostFeedType] = useState<ListingType>();
   const [postFeedSort, setPostFeedSort] = useState<SortType>();
-
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+
+  // Ref to track if the component is mounted
+  const isMounted = useRef<boolean>(false);
 
   const handleSidebarSwitch = (newState: boolean) => {
     setSidebarOpen(newState);
@@ -39,7 +41,13 @@ const Feed = ({ posts, site }: FeedProps) => {
         sort: postFeedSort
       }) : testData as unknown as GetPostsResponse);
     }
-    getPosts();
+
+    if (isMounted.current) {
+      getPosts();
+    } else {
+      // Mark component as mounted for the next render/update
+      isMounted.current = true;
+    }
   }, [postFeedSort, postFeedType]);
 
   return (

--- a/src/components/front-page-feed/index.tsx
+++ b/src/components/front-page-feed/index.tsx
@@ -20,15 +20,15 @@ interface FeedProps {
 const Feed = ({ posts, site }: FeedProps) => {
   const [postFeed, setPostFeed] = useState<GetPostsResponse>(posts);
 
-  // @todo: Set this to the users default feed type, 
+  // @todo: Set this to the users default feed type,
   // temporarily setting default values to track initial state
-  const [postFeedType, setPostFeedType] = useState<ListingType>("All");
-  const [postFeedSort, setPostFeedSort] = useState<SortType>("Hot");
+  const [postFeedType, setPostFeedType] = useState<ListingType>('All');
+  const [postFeedSort, setPostFeedSort] = useState<SortType>('Hot');
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
 
   // State to store the initial values of postFeedType and postFeedSort
-  const [initialPostFeedType, setInitialPostFeedType] = useState<ListingType>(postFeedType);
-  const [initialPostFeedSort, setInitialPostFeedSort] = useState<SortType>(postFeedSort);
+  const initialPostFeedTypeRef = useRef<ListingType>(postFeedType);
+  const initialPostFeedSortRef = useRef<SortType>(postFeedSort);
 
   const handleSidebarSwitch = (newState: boolean) => {
     setSidebarOpen(newState);
@@ -43,19 +43,21 @@ const Feed = ({ posts, site }: FeedProps) => {
         sort: postFeedSort
       }) : testData as unknown as GetPostsResponse);
     }
-    
+
+    const isPostFeedTypeChanged = postFeedType !== initialPostFeedTypeRef.current;
+    const isPostFeedSortChanged = postFeedSort !== initialPostFeedSortRef.current;
+
     // Only call getPosts if postFeedType or postFeedSort has changed from its initial value
-    if (postFeedType !== initialPostFeedType || postFeedSort !== initialPostFeedSort) {
+    if (isPostFeedTypeChanged || isPostFeedSortChanged) {
       // @todo: indication posts are loading
       try {
         getPosts();
 
         // Update initial values to reflect the current state
-        setInitialPostFeedType(postFeedType);
-        setInitialPostFeedSort(postFeedSort);
-      } catch(e) {
-        // @todo: add error handling re: src/utils/logger.ts 
-        // https://github.com/sublinks/sublinks-frontend/pull/79/commits/935bf15b1c4a5a1c3a5b1b42a4af0e291118b071
+        initialPostFeedTypeRef.current = postFeedType;
+        initialPostFeedSortRef.current = postFeedSort;
+      } catch (e) {
+        // @todo: add error handling re: src/utils/logger.ts
       }
     }
   }, [postFeedSort, postFeedType]);

--- a/src/components/front-page-feed/index.tsx
+++ b/src/components/front-page-feed/index.tsx
@@ -20,13 +20,15 @@ interface FeedProps {
 const Feed = ({ posts, site }: FeedProps) => {
   const [postFeed, setPostFeed] = useState<GetPostsResponse>(posts);
 
-  // @todo: Set this to the users default feed type
-  const [postFeedType, setPostFeedType] = useState<ListingType>();
-  const [postFeedSort, setPostFeedSort] = useState<SortType>();
+  // @todo: Set this to the users default feed type, 
+  // temporarily setting default values to track initial state
+  const [postFeedType, setPostFeedType] = useState<ListingType>("All");
+  const [postFeedSort, setPostFeedSort] = useState<SortType>("Hot");
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
 
-  // Ref to track if the component is mounted
-  const isMounted = useRef<boolean>(false);
+  // State to store the initial values of postFeedType and postFeedSort
+  const [initialPostFeedType, setInitialPostFeedType] = useState<ListingType>(postFeedType);
+  const [initialPostFeedSort, setInitialPostFeedSort] = useState<SortType>(postFeedSort);
 
   const handleSidebarSwitch = (newState: boolean) => {
     setSidebarOpen(newState);
@@ -41,12 +43,20 @@ const Feed = ({ posts, site }: FeedProps) => {
         sort: postFeedSort
       }) : testData as unknown as GetPostsResponse);
     }
+    
+    // Only call getPosts if postFeedType or postFeedSort has changed from its initial value
+    if (postFeedType !== initialPostFeedType || postFeedSort !== initialPostFeedSort) {
+      // @todo: indication posts are loading
+      try {
+        getPosts();
 
-    if (isMounted.current) {
-      getPosts();
-    } else {
-      // Mark component as mounted for the next render/update
-      isMounted.current = true;
+        // Update initial values to reflect the current state
+        setInitialPostFeedType(postFeedType);
+        setInitialPostFeedSort(postFeedSort);
+      } catch(e) {
+        // @todo: add error handling re: src/utils/logger.ts 
+        // https://github.com/sublinks/sublinks-frontend/pull/79/commits/935bf15b1c4a5a1c3a5b1b42a4af0e291118b071
+      }
     }
   }, [postFeedSort, postFeedType]);
 


### PR DESCRIPTION
Modified the Feed component to prevent the useEffect hook from running its logic on the initial component mount. Introduced a useRef hook to track the component's mount status. This change ensures that the getPosts function is only called in response to changes in postFeedSort or postFeedType, avoiding unnecessary API calls during the initial render.

https://github.com/sublinks/sublinks-frontend/issues/48