### PR TITLE
Add like/vote functionality

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,7 @@
 const commonOptions = {
   preset: 'ts-jest',
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.jest.json'
-    }
+  transform: {
+    'tsconfig.jest.json': ['ts-jest']
   }
 };
 

--- a/src/app/c/[comSlug]/[postId]/page.tsx
+++ b/src/app/c/[comSlug]/[postId]/page.tsx
@@ -4,7 +4,6 @@ import { GetPostResponse } from 'sublinks-js-client';
 import MainCard from '@/components/main-card';
 import PostHeader from '@/components/post-header';
 import LinkedPostSubTitle from '@/components/post-subtitle';
-import { getPostThumbnailUrl, isImage } from '@/utils/links';
 import SublinksApi from '@/utils/api-client/server';
 import logger from '@/utils/logger';
 
@@ -45,14 +44,8 @@ const PostView = async ({ params: { postId } }: PostViewProps) => {
   }
 
   const { post_view: postView } = postData;
-  const { my_vote: myVote } = postView;
-  const {
-    body, name: postName, url: postUrl
-  } = postView.post;
+  const { body } = postView.post;
   const { name: authorName } = postView.creator;
-  const { score } = postView.counts;
-  const postHasImage = postUrl ? isImage(postUrl) : false;
-  const thumbnailUrl = getPostThumbnailUrl(postView.post);
 
   // @todo: Make our own URLs until Sublinks API connects URLs to all entities
   const authorUrl = `/user/${authorName}`;
@@ -64,18 +57,7 @@ const PostView = async ({ params: { postId } }: PostViewProps) => {
       url={authorUrl}
     />
   );
-  const Header = (
-    <PostHeader
-      points={score}
-      title={postName}
-      SubTitle={SubTitle}
-      postUrl={postUrl}
-      thumbnailUrl={thumbnailUrl}
-      hasBody={Boolean(body)}
-      hasImage={postHasImage}
-      myVote={myVote}
-    />
-  );
+  const Header = <PostHeader postView={postData.post_view} SubTitle={SubTitle} />;
 
   return <MainCard Header={Header} body={body} />;
 };

--- a/src/app/c/[comSlug]/[postId]/page.tsx
+++ b/src/app/c/[comSlug]/[postId]/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { GetPostResponse } from 'sublinks-js-client';
 
 import MainCard from '@/components/main-card';
 import PostHeader from '@/components/post-header';
@@ -26,7 +27,7 @@ const getPost = async (postIdInt: number) => {
         id: postIdInt
       }) : { post_view: testData.posts.find(post => post.post.id === postIdInt)! };
 
-    return postData;
+    return postData as GetPostResponse;
   } catch (e) {
     logger.error('Failed to retrieve post', e);
     return undefined;
@@ -44,6 +45,7 @@ const PostView = async ({ params: { postId } }: PostViewProps) => {
   }
 
   const { post_view: postView } = postData;
+  const { my_vote: myVote } = postView;
   const {
     body, name: postName, url: postUrl
   } = postView.post;
@@ -71,6 +73,7 @@ const PostView = async ({ params: { postId } }: PostViewProps) => {
       thumbnailUrl={thumbnailUrl}
       hasBody={Boolean(body)}
       hasImage={postHasImage}
+      myVote={myVote}
     />
   );
 

--- a/src/app/user/[username]/page.tsx
+++ b/src/app/user/[username]/page.tsx
@@ -50,6 +50,7 @@ const User = async ({ params: { username } }: UserViewProps) => {
     }, is_admin: isAdmin
   } = userData.person_view;
   const { posts, comments, moderates } = userData;
+
   return (
     <div>
       <div className="mb-12">

--- a/src/components/comment-actions/index.tsx
+++ b/src/components/comment-actions/index.tsx
@@ -4,58 +4,42 @@ import React from 'react';
 import { CommentAggregates } from 'sublinks-js-client';
 import { EllipsisVerticalIcon } from '@heroicons/react/24/outline';
 
-import SublinksApi from '@/utils/api-client/client';
-import logger from '@/utils/logger';
 import Icon, { ICON_SIZE } from '../icon';
 import LinkButton from '../button-link';
 import VoteButtons from '../button-votes';
 
 interface CommentActionProps {
   votes: CommentAggregates;
+  onVote: (score: number) => void;
   myVote?: number;
 }
 
 export const CommentAction = ({
   votes,
+  onVote,
   myVote
-}: CommentActionProps) => {
-  const handleVote = async (vote: number) => {
-    if (!process.env.NEXT_PUBLIC_SUBLINKS_API_BASE_URL) return;
-
-    try {
-      await SublinksApi.Instance().Client().likeComment({
-        comment_id: votes.comment_id,
-        score: vote
-      });
-    } catch (e) {
-      logger.error(`Failed to vote on comment with ID ${votes.comment_id}`, e);
-      // @todo: Show error message/toast: https://github.com/sublinks/sublinks-frontend/issues/15
-    }
-  };
-
-  return (
-    <div className="flex relative">
-      <VoteButtons points={votes.score} onVote={handleVote} myVote={myVote} vertical />
-      <LinkButton
-        className="py-0 px-2 text-xs"
-        ariaLabel="Reply To Comment Button"
-        type="button"
-        onClick={e => {
-          e.preventDefault();
-        }}
-      >
-        Reply
-      </LinkButton>
-      <LinkButton
-        className="py-0 px-2 ml-4 text-xs"
-        ariaLabel="More Comment Actions Button"
-        type="button"
-        onClick={e => {
-          e.preventDefault();
-        }}
-      >
-        <Icon className="text-black dark:text-white hover:text-gray-400 dark:hover:text-gray-400" IconType={EllipsisVerticalIcon} size={ICON_SIZE.VERYSMALL} isInteractable />
-      </LinkButton>
-    </div>
-  );
-};
+}: CommentActionProps) => (
+  <div className="flex relative">
+    <VoteButtons points={votes.score} onVote={onVote} myVote={myVote} vertical />
+    <LinkButton
+      className="py-0 px-2 text-xs"
+      ariaLabel="Reply To Comment Button"
+      type="button"
+      onClick={e => {
+        e.preventDefault();
+      }}
+    >
+      Reply
+    </LinkButton>
+    <LinkButton
+      className="py-0 px-2 ml-4 text-xs"
+      ariaLabel="More Comment Actions Button"
+      type="button"
+      onClick={e => {
+        e.preventDefault();
+      }}
+    >
+      <Icon className="text-black dark:text-white hover:text-gray-400 dark:hover:text-gray-400" IconType={EllipsisVerticalIcon} size={ICON_SIZE.VERYSMALL} isInteractable />
+    </LinkButton>
+  </div>
+);

--- a/src/components/comment-feed/index.tsx
+++ b/src/components/comment-feed/index.tsx
@@ -12,12 +12,7 @@ const CommentFeed = ({ data: comments }: CommentFeedProps) => (
   <div className="bg-primary dark:bg-primary-dark flex flex-col gap-8">
     {comments && comments.length > 0 ? comments.map(commentData => (
       <div key={commentData.comment.ap_id} className="mb-8">
-        <CommentCard
-          comment={commentData.comment}
-          creator={commentData.creator}
-          counts={commentData.counts}
-          myVote={commentData.my_vote}
-        />
+        <CommentCard comment={commentData} />
       </div>
     )) : (<H1 className="text-center">No comments available!</H1>)}
   </div>

--- a/src/components/comment-feed/index.tsx
+++ b/src/components/comment-feed/index.tsx
@@ -16,6 +16,7 @@ const CommentFeed = ({ data: comments }: CommentFeedProps) => (
           comment={commentData.comment}
           creator={commentData.creator}
           counts={commentData.counts}
+          myVote={commentData.my_vote}
         />
       </div>
     )) : (<H1 className="text-center">No comments available!</H1>)}

--- a/src/components/comment/index.tsx
+++ b/src/components/comment/index.tsx
@@ -1,31 +1,31 @@
-import React from 'react';
+'use client';
 
-import {
-  Person, Comment, CommentAggregates
-} from 'sublinks-js-client';
+import React, { useState } from 'react';
+import { CommentView } from 'sublinks-js-client';
 import Markdown from 'react-markdown';
+
+import { handleCommentVote } from '@/utils/voting';
 import { CommentHeader } from '../comment-header';
 import { CommentAction } from '../comment-actions';
 
 interface CommentCardProps {
-  comment: Comment;
-  creator: Person;
-  counts: CommentAggregates;
-  myVote?: number;
+  comment: CommentView;
 }
 
-export const CommentCard = ({
-  comment,
-  creator,
-  counts,
-  myVote
-}: CommentCardProps) => {
+export const CommentCard = ({ comment }: CommentCardProps) => {
+  const [commentData, setCommentData] = useState(comment);
   const {
     id, content, ap_id: apId, published, updated
-  } = comment;
+  } = commentData.comment;
+  const { my_vote: myVote, creator, counts } = comment;
 
   // @todo: Make our own URLs until Sublinks API connects URLs to all entities
   const commentHref = `/comment/${id}`;
+
+  const onCommentVote = (vote: number) => {
+    const voteScore = vote === myVote ? 0 : vote;
+    handleCommentVote(id, voteScore, setCommentData);
+  };
 
   return (
     <div key={id}>
@@ -47,7 +47,7 @@ export const CommentCard = ({
           </div>
         </div>
         <div className="items-center relative flex">
-          <CommentAction votes={counts} myVote={myVote} />
+          <CommentAction votes={counts} onVote={onCommentVote} myVote={myVote} />
         </div>
       </div>
       <div className="border-b-2 border-secondary dark:border-secondary-dark" />

--- a/src/components/comment/index.tsx
+++ b/src/components/comment/index.tsx
@@ -17,7 +17,7 @@ export const CommentCard = ({ comment }: CommentCardProps) => {
   const {
     id, content, ap_id: apId, published, updated
   } = commentData.comment;
-  const { my_vote: myVote, creator, counts } = comment;
+  const { my_vote: myVote, creator, counts } = commentData;
 
   // @todo: Make our own URLs until Sublinks API connects URLs to all entities
   const commentHref = `/comment/${id}`;

--- a/src/components/post-feed/index.tsx
+++ b/src/components/post-feed/index.tsx
@@ -14,12 +14,8 @@ const PostFeed = ({ data: posts, isCommunityFeed }: PostFeedProps) => (
     {posts && posts.length > 0 ? posts.map(postData => (
       <div key={postData.post.ap_id}>
         <PostCard
-          community={postData.community}
-          counts={postData.counts}
-          creator={postData.creator}
-          post={postData.post}
+          postView={postData}
           showAuthor={isCommunityFeed}
-          myVote={postData.my_vote}
         />
       </div>
     )) : (<H1 className="text-center">No posts available!</H1>)}

--- a/src/components/post-feed/index.tsx
+++ b/src/components/post-feed/index.tsx
@@ -19,6 +19,7 @@ const PostFeed = ({ data: posts, isCommunityFeed }: PostFeedProps) => (
           creator={postData.creator}
           post={postData.post}
           showAuthor={isCommunityFeed}
+          myVote={postData.my_vote}
         />
       </div>
     )) : (<H1 className="text-center">No posts available!</H1>)}

--- a/src/components/post-header/index.tsx
+++ b/src/components/post-header/index.tsx
@@ -4,49 +4,58 @@ import React, { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import cx from 'classnames';
+import { PostView } from 'sublinks-js-client';
 
+import { getPostThumbnailUrl, isImage } from '@/utils/links';
+import { handlePostVote } from '@/utils/voting';
 import { H1 } from '../text';
 import PostThumbnail from '../post-thumbnail';
 import VoteButtons from '../button-votes';
 
 interface PostHeaderProps {
-  points: number;
-  title: string;
+  postView: PostView;
   SubTitle: React.JSX.Element;
-  postUrl?: string;
-  thumbnailUrl?: string;
-  hasBody: boolean;
-  hasImage: boolean;
-  myVote?: number;
 }
 
-const PostHeader = ({
-  points, title, SubTitle, postUrl, thumbnailUrl, hasBody, hasImage, myVote
-}: PostHeaderProps) => {
-  const [showOriginalImage, setShowOriginalImage] = useState(hasImage && !hasBody);
+const PostHeader = ({ postView, SubTitle }: PostHeaderProps) => {
+  const [postData, setPostData] = useState(postView);
+  const { my_vote: myVote } = postData;
+  const {
+    id, body, name: postName, url: postUrl
+  } = postData.post;
+  const { score } = postData.counts;
+  const postHasImage = postUrl ? isImage(postUrl) : false;
+  const thumbnailUrl = getPostThumbnailUrl(postData.post);
+
+  const [showOriginalImage, setShowOriginalImage] = useState(postHasImage && !body);
 
   let thumbnailLabel = "Go to post's URL";
-  if (hasImage) {
+  if (postHasImage) {
     thumbnailLabel = showOriginalImage ? 'Hide full-size image' : 'Show full-size image';
   }
+
+  const onPostVote = (vote: number) => {
+    const voteScore = vote === myVote ? 0 : vote;
+    handlePostVote(id, voteScore, setPostData);
+  };
 
   return (
     <div className="flex flex-col w-full">
       <div className="flex gap-8">
         <div className="flex items-start gap-8">
-          <VoteButtons points={points} onVote={() => {}} myVote={myVote} />
+          <VoteButtons points={score} onVote={onPostVote} myVote={myVote} />
           <button
             type="button"
-            aria-hidden={!hasImage}
+            aria-hidden={!postHasImage}
             aria-label={thumbnailLabel}
             className={cx('h-80 w-80 relative', {
-              'cursor-default': !postUrl || !hasBody
+              'cursor-default': !postUrl || !body
             })}
             onClick={() => {
               // Don't allow hiding image if post has no other content
-              if (hasImage && hasBody) {
-                setShowOriginalImage(hasImage && !showOriginalImage);
-              } else if (!hasImage && postUrl) {
+              if (postHasImage && body) {
+                setShowOriginalImage(postHasImage && !showOriginalImage);
+              } else if (!postHasImage && postUrl) {
                 window.open(postUrl, '_blank', 'noopener noreferrer');
               }
             }}
@@ -57,9 +66,9 @@ const PostHeader = ({
         <div className="flex flex-col">
           {postUrl ? (
             <Link href={postUrl} target="_blank" rel="noopener noreferrer">
-              <H1 className="hover:text-brand dark:hover:text-brand-dark">{title}</H1>
+              <H1 className="hover:text-brand dark:hover:text-brand-dark">{postName}</H1>
             </Link>
-          ) : <H1>{title}</H1>}
+          ) : <H1>{postName}</H1>}
           {SubTitle}
         </div>
       </div>

--- a/src/components/post-header/index.tsx
+++ b/src/components/post-header/index.tsx
@@ -17,10 +17,11 @@ interface PostHeaderProps {
   thumbnailUrl?: string;
   hasBody: boolean;
   hasImage: boolean;
+  myVote?: number;
 }
 
 const PostHeader = ({
-  points, title, SubTitle, postUrl, thumbnailUrl, hasBody, hasImage
+  points, title, SubTitle, postUrl, thumbnailUrl, hasBody, hasImage, myVote
 }: PostHeaderProps) => {
   const [showOriginalImage, setShowOriginalImage] = useState(hasImage && !hasBody);
 
@@ -33,7 +34,7 @@ const PostHeader = ({
     <div className="flex flex-col w-full">
       <div className="flex gap-8">
         <div className="flex items-start gap-8">
-          <VoteButtons points={points} onVote={() => {}} />
+          <VoteButtons points={points} onVote={() => {}} myVote={myVote} />
           <button
             type="button"
             aria-hidden={!hasImage}

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -18,6 +18,7 @@ interface PostCardProps {
   creator: Person;
   community: Community;
   counts: PostAggregates;
+  myVote?: number;
   showAuthor?: boolean;
 }
 
@@ -26,6 +27,7 @@ export const PostCard = ({
   creator,
   community,
   counts,
+  myVote,
   showAuthor
 }: PostCardProps) => {
   const { id, body, name: title } = post;
@@ -44,7 +46,7 @@ export const PostCard = ({
     <div key={id}>
       <div className="flex">
         <div className="flex items-center ml-8">
-          <VoteButtons points={score} onVote={() => {}} myVote={0} />
+          <VoteButtons points={score} onVote={() => {}} myVote={myVote} />
         </div>
         <div className="w-full">
           <div className="flex h-100 relative">

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -6,8 +6,7 @@ import { PostView } from 'sublinks-js-client';
 
 import { getCommunitySlugFromUrl } from '@/utils/communities';
 import { getPostThumbnailUrl } from '@/utils/links';
-import SublinksApi from '@/utils/api-client/client';
-import logger from '@/utils/logger';
+import { handlePostVote } from '@/utils/voting';
 import { BodyText, BodyTitle } from '../text';
 import PostThumbnail from '../post-thumbnail';
 import LinkedPostSubTitle from '../post-subtitle';
@@ -39,26 +38,16 @@ export const PostCard = ({
   const authorUrl = `/user/${authorName}`;
   const communityUrl = `/c/${communitySlug}`;
 
-  const handlePostVote = async (vote: number) => {
+  const onPostVote = (vote: number) => {
     const voteScore = vote === myVote ? 0 : vote;
-
-    try {
-      const updatedPost = await SublinksApi.Instance().Client().likePost({
-        post_id: id,
-        score: voteScore
-      });
-
-      setPostData(updatedPost.post_view);
-    } catch (e) {
-      logger.error(`Failed to like post with ID ${id} and score ${voteScore}`, e);
-    }
+    handlePostVote(id, voteScore, setPostData);
   };
 
   return (
     <div key={id}>
       <div className="flex">
         <div className="flex items-center ml-8">
-          <VoteButtons points={score} onVote={handlePostVote} myVote={myVote} />
+          <VoteButtons points={score} onVote={onPostVote} myVote={myVote} />
         </div>
         <div className="w-full">
           <div className="flex h-100 relative">

--- a/src/utils/__tests__/voting.test.ts
+++ b/src/utils/__tests__/voting.test.ts
@@ -1,0 +1,41 @@
+import { GetPostResponse, SublinksClient } from 'sublinks-js-client';
+
+import logger from '../logger';
+import { handlePostVote } from '../voting';
+
+afterEach(() => jest.clearAllMocks());
+
+describe('handlePostVote', () => {
+  it('sends API request to vote on post and triggers callback', async () => {
+    const postView = {
+      post: {
+        id: 999
+      },
+      counts: {
+        score: 10
+      },
+      my_vote: 1
+    };
+    const mockDispatchFn = jest.fn();
+
+    jest.spyOn(SublinksClient.prototype, 'likePost').mockResolvedValue({
+      post_view: postView
+    } as GetPostResponse);
+
+    await handlePostVote(postView.post.id, 1, mockDispatchFn);
+
+    expect(mockDispatchFn).toHaveBeenCalledWith(postView);
+  });
+
+  it('logs error on API request error', async () => {
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    const mockDispatchFn = jest.fn();
+
+    jest.spyOn(SublinksClient.prototype, 'likePost').mockRejectedValue('401');
+
+    await handlePostVote(99, 1, mockDispatchFn);
+
+    expect(mockDispatchFn).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/utils/api-client/base.ts
+++ b/src/utils/api-client/base.ts
@@ -94,8 +94,10 @@ class SublinksApiBase {
         const userIsAuthenticated = Boolean(site.my_user);
 
         if (authCookie && userIsAuthenticated) {
-          this.setAuthHeader(authCookie);
-        } else if (this.rawClient.headers.Authorization) {
+          return;
+        }
+
+        if (this.rawClient.headers.Authorization) {
           this.clearAuth();
         }
       } catch (e) {
@@ -115,6 +117,7 @@ class SublinksApiBase {
           const authCookie = this.authCookieStore?.get();
 
           if (authCookie && !this.rawClient.headers.Authorization) {
+            this.setAuthHeader(authCookie);
             await validateAndUpdateAuth(authCookie);
           }
 

--- a/src/utils/voting.ts
+++ b/src/utils/voting.ts
@@ -1,6 +1,6 @@
 import { PostView } from 'sublinks-js-client';
 
-import SublinksApi from '@/utils/api-client/client';
+import SublinksApi from './api-client/client';
 import logger from './logger';
 
 export const handlePostVote = async (

--- a/src/utils/voting.ts
+++ b/src/utils/voting.ts
@@ -1,4 +1,4 @@
-import { PostView } from 'sublinks-js-client';
+import { CommentView, PostView } from 'sublinks-js-client';
 
 import SublinksApi from './api-client/client';
 import logger from './logger';
@@ -17,5 +17,22 @@ export const handlePostVote = async (
     postDataCallback(updatedPost.post_view);
   } catch (e) {
     logger.error(`Failed to like post with ID ${postId} and score ${vote}`, e);
+  }
+};
+
+export const handleCommentVote = async (
+  commentId: number,
+  vote: number,
+  commentDataCallback: React.Dispatch<React.SetStateAction<CommentView>>
+) => {
+  try {
+    const updatedComment = await SublinksApi.Instance().Client().likeComment({
+      comment_id: commentId,
+      score: vote
+    });
+
+    commentDataCallback(updatedComment.comment_view);
+  } catch (e) {
+    logger.error(`Failed to like comment with ID ${commentId} and score ${vote}`, e);
   }
 };

--- a/src/utils/voting.ts
+++ b/src/utils/voting.ts
@@ -1,0 +1,21 @@
+import { PostView } from 'sublinks-js-client';
+
+import SublinksApi from '@/utils/api-client/client';
+import logger from './logger';
+
+export const handlePostVote = async (
+  postId: number,
+  vote: number,
+  postDataCallback: React.Dispatch<React.SetStateAction<PostView>>
+) => {
+  try {
+    const updatedPost = await SublinksApi.Instance().Client().likePost({
+      post_id: postId,
+      score: vote
+    });
+
+    postDataCallback(updatedPost.post_view);
+  } catch (e) {
+    logger.error(`Failed to like post with ID ${postId} and score ${vote}`, e);
+  }
+};


### PR DESCRIPTION
This connects ou4 voting buttons to the API action of liking/voting on posts and comments.

It also adds a patch to the API client class which I noticed has some discrepancies on the server-side.

Plus, it also renders a comment feed on the post pages. Although it was mainly to enable testing of comment voting. Not too much thought was put into layout and such. That'll happen in the future.