### PR TITLE
Issue/62

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,6 +58,7 @@ const RootLayout = async ({
   children: React.ReactNode
 }) => {
   const site = await getSite();
+  const initialTheme = site?.my_user?.local_user_view?.local_user?.theme ?? 'dark';
   const theme = {
     menu: {
       defaultProps: {
@@ -71,7 +72,7 @@ const RootLayout = async ({
   return (
     <UserProvider>
       <ThemeProvider value={theme}>
-        <html lang="en" className="h-full dark">
+        <html lang="en" className={`h-full ${initialTheme}`}>
           <body className={cx(inter.className, 'flex flex-col min-h-full bg-secondary dark:bg-secondary-dark')}>
             <Header site={site} />
             <BottomNav site={site} />

--- a/src/components/user-nav/index.tsx
+++ b/src/components/user-nav/index.tsx
@@ -19,7 +19,8 @@ import { LinkText } from '../text';
 import Icon, { ICON_SIZE } from '../icon';
 
 const ProfileMenu = ({ myUser }: { myUser: MyUserInfo }) => {
-  const [theme, setTheme] = useTheme();
+  const initialTheme = myUser?.local_user_view?.local_user?.theme;
+  const [theme, setTheme] = useTheme(initialTheme);
   const [open, setOpen] = useState<boolean>(false);
 
   const ref = useClickOutside<HTMLUListElement>(() => open && setOpen(false));

--- a/src/components/user-nav/index.tsx
+++ b/src/components/user-nav/index.tsx
@@ -12,14 +12,14 @@ import {
 import { MyUserInfo } from 'sublinks-js-client';
 
 import { UserContext } from '@/context/user';
-import { useTheme } from '@/hooks/use-theme';
+import { Theme, useTheme } from '@/hooks/use-theme';
 import { useClickOutside } from '@/hooks/use-click-outside';
 import ThemeSwitch from '../theme-switch';
 import { LinkText } from '../text';
 import Icon, { ICON_SIZE } from '../icon';
 
 const ProfileMenu = ({ myUser }: { myUser: MyUserInfo }) => {
-  const initialTheme = myUser?.local_user_view?.local_user?.theme;
+  const initialTheme = myUser?.local_user_view?.local_user?.theme as Theme;
   const [theme, setTheme] = useTheme(initialTheme);
   const [open, setOpen] = useState<boolean>(false);
 
@@ -65,21 +65,21 @@ const ProfileMenu = ({ myUser }: { myUser: MyUserInfo }) => {
   return (
     <div className="flex justify-center items-center">
       {false && ( // @todo: Change to check if a user is logged in
-      <Link href="/inbox">
-        <Icon IconType={BellIcon} size={ICON_SIZE.SMALL} title="Inbox icon" isInteractable />
-      </Link>
+        <Link href="/inbox">
+          <Icon IconType={BellIcon} size={ICON_SIZE.SMALL} title="Inbox icon" isInteractable />
+        </Link>
       )}
 
       {false && ( // @todo: Change to check if a user is a mod or an admin
-      <Link href="/reports">
-        <Icon IconType={ShieldExclamationIcon} size={ICON_SIZE.SMALL} title="Reports icon" isInteractable />
-      </Link>
+        <Link href="/reports">
+          <Icon IconType={ShieldExclamationIcon} size={ICON_SIZE.SMALL} title="Reports icon" isInteractable />
+        </Link>
       )}
 
       {false && ( // @todo: Change to check if applications are enabled and the user is an admin
-      <Link href="/registration_applications">
-        <Icon IconType={ClipboardIcon} size={ICON_SIZE.SMALL} title="Registration applications icon" isInteractable />
-      </Link>
+        <Link href="/registration_applications">
+          <Icon IconType={ClipboardIcon} size={ICON_SIZE.SMALL} title="Registration applications icon" isInteractable />
+        </Link>
       )}
 
       <Menu

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,11 +1,14 @@
 'use client';
 
+type Theme = 'light' | 'dark';
+
 import { useLocalStorage } from '@/hooks/use-local-storage';
 import { handleSaveUserSettings } from '@/utils/settings';
 
-export function useTheme() {
+export function useTheme(initialTheme?: Theme ) {
+   initialTheme = initialTheme ?? (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
-   const [theme, setTheme] = useLocalStorage('theme', typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+   const [theme, setTheme] = useLocalStorage('theme', initialTheme);
 
    const saveTheme = async (newTheme) => {
       const oldTheme = theme;

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,7 +1,18 @@
 'use client';
 
 import { useLocalStorage } from '@/hooks/use-local-storage';
+import { handleSaveUserSettings } from '@/utils/settings';
 
 export function useTheme() {
-  return useLocalStorage('theme', typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+
+   const [theme, setTheme] = useLocalStorage('theme', typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+
+   const saveTheme = async (newTheme) => {
+      const oldTheme = theme;
+      setTheme(newTheme);
+      
+      const newUserSettings = await handleSaveUserSettings({ theme: newTheme });
+   }
+
+   return [theme, saveTheme];
 }

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -3,14 +3,14 @@
 import { useLocalStorage } from '@/hooks/use-local-storage';
 import { handleSaveUserSettings } from '@/utils/settings';
 
-type Theme = 'light' | 'dark';
+export type Theme = 'light' | 'dark';
 
-export function useTheme(initialTheme?: Theme) {
+export function useTheme(initialTheme: Theme): [Theme, (theme: Theme) => void] {
   const originalTheme = initialTheme ?? (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
   const [theme, setTheme] = useLocalStorage('theme', originalTheme);
 
-  const saveTheme = async newTheme => {
+  const saveTheme = async (newTheme: Theme) => {
     setTheme(newTheme);
 
     await handleSaveUserSettings({ theme: newTheme });

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,21 +1,20 @@
 'use client';
 
-type Theme = 'light' | 'dark';
-
 import { useLocalStorage } from '@/hooks/use-local-storage';
 import { handleSaveUserSettings } from '@/utils/settings';
 
-export function useTheme(initialTheme?: Theme ) {
-   initialTheme = initialTheme ?? (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+type Theme = 'light' | 'dark';
 
-   const [theme, setTheme] = useLocalStorage('theme', initialTheme);
+export function useTheme(initialTheme?: Theme) {
+  const originalTheme = initialTheme ?? (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
-   const saveTheme = async (newTheme) => {
-      const oldTheme = theme;
-      setTheme(newTheme);
-      
-      const newUserSettings = await handleSaveUserSettings({ theme: newTheme });
-   }
+  const [theme, setTheme] = useLocalStorage('theme', originalTheme);
 
-   return [theme, saveTheme];
+  const saveTheme = async newTheme => {
+    setTheme(newTheme);
+
+    await handleSaveUserSettings({ theme: newTheme });
+  };
+
+  return [theme, saveTheme];
 }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,0 +1,13 @@
+import { SaveUserSettings } from 'sublinks-js-client';
+
+import SublinksApi from './api-client/client';
+import logger from './logger';
+
+export const handleSaveUserSettings = async ( userSettings: SaveUserSettings) => {
+
+   try {
+      const updatedUserSettings = await SublinksApi.Instance().Client().saveUserSettings(userSettings);
+   } catch (e) {
+      logger.error(`Failed to save user settings ${userSettings}`, e);
+   }
+};

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -3,11 +3,10 @@ import { SaveUserSettings } from 'sublinks-js-client';
 import SublinksApi from './api-client/client';
 import logger from './logger';
 
-export const handleSaveUserSettings = async ( userSettings: SaveUserSettings) => {
-
-   try {
-      const updatedUserSettings = await SublinksApi.Instance().Client().saveUserSettings(userSettings);
-   } catch (e) {
-      logger.error(`Failed to save user settings ${userSettings}`, e);
-   }
+export const handleSaveUserSettings = async (userSettings: SaveUserSettings) => {
+  try {
+    await SublinksApi.Instance().Client().saveUserSettings(userSettings);
+  } catch (e) {
+    logger.error(`Failed to save user settings ${userSettings}`, e);
+  }
 };


### PR DESCRIPTION
Adds the ability to save and restore the theme style (light or dark) to/from the database. 

We might need to consider if we're overloading the term theme. We seem to be using it both to refer to a tailwind theme / color scheme and to refer to a light/dark mode. 

This PR will load the theme from the DB if present, else will check localStorage, else use default theme from the server.

There's still an issue if the user is authenticated and the user has chosen the light theme then the dark theme still flashes as that's what the server renders and the user theme is applied client side. I'm not totally sure the "right" way to address that. But if anyone has ideas on that I'm open to pursuing it.